### PR TITLE
Abstracts the amount of thumbnails per line to a setting

### DIFF
--- a/inc/functions_post.php
+++ b/inc/functions_post.php
@@ -1008,7 +1008,7 @@ function get_post_attachments($id, &$post)
 					if($attachment['thumbnail'] != "SMALL" && $attachment['thumbnail'] != "" && $mybb->settings['attachthumbnails'] == "yes")
 					{
 						eval("\$post['thumblist'] .= \"".$templates->get("postbit_attachments_thumbnails_thumbnail")."\";");
-						if($tcount == 5)
+						if($tcount == $mybb->settings['thumbnailsperline'])
 						{
 							$post['thumblist'] .= "<br />";
 							$tcount = 0;
@@ -1024,7 +1024,7 @@ function get_post_attachments($id, &$post)
 						else 
 						{
 							eval("\$post['thumblist'] .= \"".$templates->get("postbit_attachments_thumbnails_thumbnail")."\";");
-							if($tcount == 5)
+							if($tcount == $mybb->settings['thumbnailsperline'])
 							{
 								$post['thumblist'] .= "<br />";
 								$tcount = 0;

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -1539,7 +1539,7 @@ min=1]]></optionscode>
 		</setting>
 		<setting name="thumbnailsperline">
 			<title>Amount of Thumbnails per line</title>
-			<description><![CDATA[Enter the amount of thumbnails that should be shown per line.]></description>
+			<description><![CDATA[Enter the amount of thumbnails that should be shown per line.]]></description>
 			<disporder>6</disporder>
 			<optionscode><![CDATA[numeric
 min=1]]></optionscode>

--- a/install/resources/settings.xml
+++ b/install/resources/settings.xml
@@ -1537,6 +1537,15 @@ min=1]]></optionscode>
 			<settingvalue><![CDATA[96]]></settingvalue>
 			<isdefault>1</isdefault>
 		</setting>
+		<setting name="thumbnailsperline">
+			<title>Amount of Thumbnails per line</title>
+			<description><![CDATA[Enter the amount of thumbnails that should be shown per line.]></description>
+			<disporder>6</disporder>
+			<optionscode><![CDATA[numeric
+min=1]]></optionscode>
+			<settingvalue><![CDATA[5]]></settingvalue>
+			<isdefault>1</isdefault>
+		</setting>
 	</settinggroup>
 	<settinggroup name="memberlist" title="Member List" description="This section allows you to control various aspects of the board member listing (memberlist.php), such as how many members to show per page, and which features to enable or disable." disporder="13" isdefault="1">
 		<setting name="enablememberlist">

--- a/portal.php
+++ b/portal.php
@@ -713,7 +713,7 @@ if(!empty($mybb->settings['portal_announcementsfid']))
 							if($attachment['thumbnail'] != "SMALL" && $attachment['thumbnail'] != '')
 							{ // We have a thumbnail to show
 								eval("\$post['thumblist'] .= \"".$templates->get("postbit_attachments_thumbnails_thumbnail")."\";");
-								if($tcount == 5)
+								if($tcount == $mybb->settings['thumbnailsperline'])
 								{
 									$post['thumblist'] .= "<br />";
 									$tcount = 0;


### PR DESCRIPTION
I abstracted the amount of thumbnails per line to a setting and used the setting instead of the magic number `5`.